### PR TITLE
chore: upgrade samples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -560,16 +560,16 @@
                 "@testing-library/react": "^13.4.0",
                 "@types/jest": "^29.5.0",
                 "@types/node": "^20.5.1",
-                "@types/react": "^18.2.13 || ^19.1.2",
-                "@types/react-dom": "^18.2.6 || ^19.1.2",
+                "@types/react": "^19.1.2",
+                "@types/react-dom": "^19.1.2",
                 "eslint-config-msal": "file:../../shared-configs/eslint-config-msal",
                 "jest": "^29.5.0",
                 "jest-environment-jsdom": "^29.5.0",
                 "jest-junit": "^16.0.0",
                 "msal-test-utils": "file:../../shared-test-utils",
                 "prettier": "2.8.7",
-                "react": "^18.2.0 || ^19.1.0",
-                "react-dom": "^18.2.0 || ^19.1.0",
+                "react": "^19.1.0",
+                "react-dom": "^19.1.0",
                 "rollup": "^4.22.4",
                 "ts-jest": "^29.1.0",
                 "ts-jest-resolver": "^2.0.1",
@@ -592,6 +592,56 @@
             "dependencies": {
                 "undici-types": "~6.19.2"
             }
+        },
+        "lib/msal-react/node_modules/@types/react": {
+            "version": "19.1.3",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
+            "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.0.2"
+            }
+        },
+        "lib/msal-react/node_modules/@types/react-dom": {
+            "version": "19.1.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
+            "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^19.0.0"
+            }
+        },
+        "lib/msal-react/node_modules/react": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "lib/msal-react/node_modules/react-dom": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.26.0"
+            },
+            "peerDependencies": {
+                "react": "^19.1.0"
+            }
+        },
+        "lib/msal-react/node_modules/scheduler": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@adobe/css-tools": {
             "version": "4.4.1",
@@ -15190,6 +15240,7 @@
             "version": "18.3.5",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
             "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+            "dev": true,
             "peerDependencies": {
                 "@types/react": "^18.0.0"
             }
@@ -61070,8 +61121,8 @@
                 "@emotion/styled": "^11.9.3",
                 "@mui/icons-material": "^5.8.4",
                 "@mui/material": "^5.9.0",
-                "react": "^18.0.0",
-                "react-dom": "^18.0.0",
+                "react": "^19.1.0",
+                "react-dom": "^19.1.0",
                 "react-router-dom": "^6.7.0"
             },
             "devDependencies": {
@@ -61083,6 +61134,33 @@
                 "react-scripts": "5.0.1",
                 "ts-jest": "^29.1.0"
             }
+        },
+        "samples/msal-react-samples/b2c-sample/node_modules/react": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "samples/msal-react-samples/b2c-sample/node_modules/react-dom": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.26.0"
+            },
+            "peerDependencies": {
+                "react": "^19.1.0"
+            }
+        },
+        "samples/msal-react-samples/b2c-sample/node_modules/scheduler": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+            "license": "MIT"
         },
         "samples/msal-react-samples/nextjs-sample": {
             "name": "next-js-msal-react-sample",
@@ -61097,8 +61175,8 @@
                 "@mui/icons-material": "^5.10.14",
                 "@mui/material": "^5.10.14",
                 "next": "^14.2.26",
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
+                "react": "^19.1.0",
+                "react-dom": "^19.1.0"
             },
             "devDependencies": {
                 "@types/jest": "^29.5.2",
@@ -61107,6 +61185,33 @@
                 "jest-junit": "^16.0.0",
                 "ts-jest": "^29.1.0"
             }
+        },
+        "samples/msal-react-samples/nextjs-sample/node_modules/react": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "samples/msal-react-samples/nextjs-sample/node_modules/react-dom": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.26.0"
+            },
+            "peerDependencies": {
+                "react": "^19.1.0"
+            }
+        },
+        "samples/msal-react-samples/nextjs-sample/node_modules/scheduler": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+            "license": "MIT"
         },
         "samples/msal-react-samples/react-router-sample": {
             "version": "0.1.0",
@@ -61117,8 +61222,8 @@
                 "@emotion/styled": "^11.10.5",
                 "@mui/icons-material": "^5.10.16",
                 "@mui/material": "^5.10.17",
-                "react": "^18.0.0",
-                "react-dom": "^18.0.0",
+                "react": "^19.1.0",
+                "react-dom": "^19.1.0",
                 "react-router-dom": "^6.7.0",
                 "react-scripts": "^5.0.1"
             },
@@ -61132,6 +61237,33 @@
                 "ts-jest": "^29.1.0"
             }
         },
+        "samples/msal-react-samples/react-router-sample/node_modules/react": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "samples/msal-react-samples/react-router-sample/node_modules/react-dom": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.26.0"
+            },
+            "peerDependencies": {
+                "react": "^19.1.0"
+            }
+        },
+        "samples/msal-react-samples/react-router-sample/node_modules/scheduler": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+            "license": "MIT"
+        },
         "samples/msal-react-samples/typescript-sample": {
             "version": "0.1.0",
             "dependencies": {
@@ -61142,11 +61274,11 @@
                 "@mui/icons-material": "^5.10.16",
                 "@mui/material": "^5.10.17",
                 "@types/node": "^16.18.10",
-                "@types/react": "^18.0.26",
-                "@types/react-dom": "^18.0.9",
+                "@types/react": "^19.1.3",
+                "@types/react-dom": "^19.1.3",
                 "@types/react-router-dom": "^5.1.7",
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0",
+                "react": "^19.1.0",
+                "react-dom": "^19.1.0",
                 "react-router-dom": "^6.7.0",
                 "react-scripts": "5.0.1",
                 "typescript": "^4.9.4"
@@ -61164,6 +61296,51 @@
             "version": "16.18.125",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.125.tgz",
             "integrity": "sha512-w7U5ojboSPfZP4zD98d+/cjcN2BDW6lKH2M0ubipt8L8vUC7qUAC6ENKGSJL4tEktH2Saw2K4y1uwSjyRGKMhw=="
+        },
+        "samples/msal-react-samples/typescript-sample/node_modules/@types/react": {
+            "version": "19.1.3",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
+            "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.0.2"
+            }
+        },
+        "samples/msal-react-samples/typescript-sample/node_modules/@types/react-dom": {
+            "version": "19.1.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
+            "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^19.0.0"
+            }
+        },
+        "samples/msal-react-samples/typescript-sample/node_modules/react": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "samples/msal-react-samples/typescript-sample/node_modules/react-dom": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.26.0"
+            },
+            "peerDependencies": {
+                "react": "^19.1.0"
+            }
+        },
+        "samples/msal-react-samples/typescript-sample/node_modules/scheduler": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+            "license": "MIT"
         },
         "shared-configs/eslint-config-msal": {
             "version": "0.0.0",

--- a/samples/msal-react-samples/b2c-sample/package.json
+++ b/samples/msal-react-samples/b2c-sample/package.json
@@ -9,8 +9,8 @@
         "@emotion/styled": "^11.9.3",
         "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.9.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
         "react-router-dom": "^6.7.0"
     },
     "devDependencies": {

--- a/samples/msal-react-samples/nextjs-sample/next-env.d.ts
+++ b/samples/msal-react-samples/nextjs-sample/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/samples/msal-react-samples/nextjs-sample/package.json
+++ b/samples/msal-react-samples/nextjs-sample/package.json
@@ -19,8 +19,8 @@
     "@mui/icons-material": "^5.10.14",
     "@mui/material": "^5.10.14",
     "next": "^14.2.26",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.2",

--- a/samples/msal-react-samples/react-router-sample/package.json
+++ b/samples/msal-react-samples/react-router-sample/package.json
@@ -9,8 +9,8 @@
     "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.10.16",
     "@mui/material": "^5.10.17",
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "react-router-dom": "^6.7.0",
     "react-scripts": "^5.0.1"
   },

--- a/samples/msal-react-samples/typescript-sample/package.json
+++ b/samples/msal-react-samples/typescript-sample/package.json
@@ -10,11 +10,11 @@
         "@mui/icons-material": "^5.10.16",
         "@mui/material": "^5.10.17",
         "@types/node": "^16.18.10",
-        "@types/react": "^18.0.26",
-        "@types/react-dom": "^18.0.9",
+        "@types/react": "^19.1.3",
+        "@types/react-dom": "^19.1.3",
         "@types/react-router-dom": "^5.1.7",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
+        "react": "^19.1.0",
+        "react-dom": "^19.1.0",
         "react-router-dom": "^6.7.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.4"
@@ -50,5 +50,5 @@
         "suiteNameTemplate": "TypeScript Sample Tests",
         "outputDirectory": ".",
         "outputName": "test-results.xml"
-      }
+    }
 }


### PR DESCRIPTION
installed react 19 in samples, ran build in samples and npm install to fix some lockfile errors