### PR TITLE
chore: dedupe react packages

### DIFF
--- a/lib/msal-react/package.json
+++ b/lib/msal-react/package.json
@@ -64,7 +64,7 @@
     "@microsoft/api-extractor": "^7.43.4",
     "@rollup/plugin-typescript": "^11.1.5",
     "@testing-library/jest-dom": "^5.11.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^16.3.0",
     "@types/jest": "^29.5.0",
     "@types/node": "^20.5.1",
     "@types/react": "^19.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36457,6 +36457,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -36676,6 +36677,7 @@
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -40124,6 +40126,7 @@
             "version": "0.23.2",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
             "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             }
@@ -60647,9 +60650,9 @@
                 "axios": "^1.8.2",
                 "bootstrap": "^5.0.0",
                 "electron-squirrel-startup": "^1.0.0",
-                "react": "^18.2.0",
+                "react": "^19.1.0",
                 "react-bootstrap": "^2.7.2",
-                "react-dom": "^18.2.0",
+                "react-dom": "^19.1.0",
                 "react-router-dom": "^6.9.0"
             },
             "devDependencies": {
@@ -60662,8 +60665,8 @@
                 "@electron/asar": "^3.2.3",
                 "@playwright/test": "^1.31.1",
                 "@types/jest": "^29.5.0",
-                "@types/react": "^18.0.28",
-                "@types/react-dom": "^18.0.11",
+                "@types/react": "^19.1.3",
+                "@types/react-dom": "^19.1.3",
                 "@typescript-eslint/eslint-plugin": "^5.0.0",
                 "@typescript-eslint/parser": "^5.0.0",
                 "@vercel/webpack-asset-relocator-loader": "1.7.3",
@@ -60685,6 +60688,26 @@
                 "ts-loader": "^9.2.2",
                 "ts-node": "^10.0.0",
                 "typescript": "~4.5.4"
+            }
+        },
+        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/@types/react": {
+            "version": "19.1.3",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
+            "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "csstype": "^3.0.2"
+            }
+        },
+        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/@types/react-dom": {
+            "version": "19.1.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
+            "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "^19.0.0"
             }
         },
         "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/@vercel/webpack-asset-relocator-loader": {
@@ -60768,6 +60791,33 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/react": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/react-dom": {
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+            "license": "MIT",
+            "dependencies": {
+                "scheduler": "^0.26.0"
+            },
+            "peerDependencies": {
+                "react": "^19.1.0"
+            }
+        },
+        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/scheduler": {
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+            "license": "MIT"
         },
         "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/ts-node": {
             "version": "10.9.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -557,7 +557,7 @@
                 "@microsoft/api-extractor": "^7.43.4",
                 "@rollup/plugin-typescript": "^11.1.5",
                 "@testing-library/jest-dom": "^5.11.5",
-                "@testing-library/react": "^13.4.0",
+                "@testing-library/react": "^16.3.0",
                 "@types/jest": "^29.5.0",
                 "@types/node": "^20.5.1",
                 "@types/react": "^19.1.2",
@@ -584,6 +584,55 @@
                 "react": "^16.8.0 || ^17 || ^18 || ^19"
             }
         },
+        "lib/msal-react/node_modules/@testing-library/dom": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+            "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "chalk": "^4.1.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "lib/msal-react/node_modules/@testing-library/react": {
+            "version": "16.3.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+            "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "lib/msal-react/node_modules/@types/node": {
             "version": "20.17.16",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.16.tgz",
@@ -593,55 +642,16 @@
                 "undici-types": "~6.19.2"
             }
         },
-        "lib/msal-react/node_modules/@types/react": {
-            "version": "19.1.3",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
-            "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
+        "lib/msal-react/node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
             "dev": true,
-            "license": "MIT",
+            "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
-                "csstype": "^3.0.2"
+                "dequal": "^2.0.3"
             }
-        },
-        "lib/msal-react/node_modules/@types/react-dom": {
-            "version": "19.1.3",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
-            "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "^19.0.0"
-            }
-        },
-        "lib/msal-react/node_modules/react": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "lib/msal-react/node_modules/react-dom": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "scheduler": "^0.26.0"
-            },
-            "peerDependencies": {
-                "react": "^19.1.0"
-            }
-        },
-        "lib/msal-react/node_modules/scheduler": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@adobe/css-tools": {
             "version": "4.4.1",
@@ -6742,6 +6752,16 @@
                 "vue": "^3.2.0"
             }
         },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.3.tgz",
+            "integrity": "sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@emotion/babel-plugin": {
             "version": "11.13.5",
             "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.13.5.tgz",
@@ -7465,6 +7485,383 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "deprecated": "Use @eslint/object-schema instead"
+        },
+        "node_modules/@img/sharp-darwin-arm64": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.1.tgz",
+            "integrity": "sha512-pn44xgBtgpEbZsu+lWf2KNb6OAf70X68k+yk69Ic2Xz11zHR/w24/U49XT7AeRwJ0Px+mhALhU5LPci1Aymk7A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-arm64": "1.1.0"
+            }
+        },
+        "node_modules/@img/sharp-darwin-x64": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.1.tgz",
+            "integrity": "sha512-VfuYgG2r8BpYiOUN+BfYeFo69nP/MIwAtSJ7/Zpxc5QF3KS22z8Pvg3FkrSFJBPNQ7mmcUcYQFBmEQp7eu1F8Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-darwin-x64": "1.1.0"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-arm64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.1.0.tgz",
+            "integrity": "sha512-HZ/JUmPwrJSoM4DIQPv/BfNh9yrOA8tlBbqbLz4JZ5uew2+o22Ik+tHQJcih7QJuSa0zo5coHTfD5J8inqj9DA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-darwin-x64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.1.0.tgz",
+            "integrity": "sha512-Xzc2ToEmHN+hfvsl9wja0RlnXEgpKNmftriQp6XzY/RaSfwD9th+MSh0WQKzUreLKKINb3afirxW7A0fz2YWuQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.1.0.tgz",
+            "integrity": "sha512-s8BAd0lwUIvYCJyRdFqvsj+BJIpDBSxs6ivrOPm/R7piTs5UIwY5OjXrP2bqXC9/moGsyRa37eYWYCOGVXxVrA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-arm64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.1.0.tgz",
+            "integrity": "sha512-IVfGJa7gjChDET1dK9SekxFFdflarnUB8PwW8aGwEoF3oAsSDuNUTYS+SKDOyOJxQyDC1aPFMuRYLoDInyV9Ew==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-ppc64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.1.0.tgz",
+            "integrity": "sha512-tiXxFZFbhnkWE2LA8oQj7KYR+bWBkiV2nilRldT7bqoEZ4HiDOcePr9wVDAZPi/Id5fT1oY9iGnDq20cwUz8lQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-s390x": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.1.0.tgz",
+            "integrity": "sha512-xukSwvhguw7COyzvmjydRb3x/09+21HykyapcZchiCUkTThEQEOMtBj9UhkaBRLuBrgLFzQ2wbxdeCCJW/jgJA==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linux-x64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.1.0.tgz",
+            "integrity": "sha512-yRj2+reB8iMg9W5sULM3S74jVS7zqSzHG3Ol/twnAAkAhnGQnpjj6e4ayUz7V+FpKypwgs82xbRdYtchTTUB+Q==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.1.0.tgz",
+            "integrity": "sha512-jYZdG+whg0MDK+q2COKbYidaqW/WTz0cc1E+tMAusiDygrM4ypmSCjOJPmFTvHHJ8j/6cAGyeDWZOsK06tP33w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.1.0.tgz",
+            "integrity": "sha512-wK7SBdwrAiycjXdkPnGCPLjYb9lD4l6Ze2gSdAGVZrEL05AOUJESWU2lhlC+Ffn5/G+VKuSm6zzbQSzFX/P65A==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.1.tgz",
+            "integrity": "sha512-anKiszvACti2sGy9CirTlNyk7BjjZPiML1jt2ZkTdcvpLU1YH6CXwRAZCA2UmRXnhiIftXQ7+Oh62Ji25W72jA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm": "1.1.0"
+            }
+        },
+        "node_modules/@img/sharp-linux-arm64": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.1.tgz",
+            "integrity": "sha512-kX2c+vbvaXC6vly1RDf/IWNXxrlxLNpBVWkdpRq5Ka7OOKj6nr66etKy2IENf6FtOgklkg9ZdGpEu9kwdlcwOQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-arm64": "1.1.0"
+            }
+        },
+        "node_modules/@img/sharp-linux-s390x": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.1.tgz",
+            "integrity": "sha512-7s0KX2tI9mZI2buRipKIw2X1ufdTeaRgwmRabt5bi9chYfhur+/C1OXg3TKg/eag1W+6CCWLVmSauV1owmRPxA==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-s390x": "1.1.0"
+            }
+        },
+        "node_modules/@img/sharp-linux-x64": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.1.tgz",
+            "integrity": "sha512-wExv7SH9nmoBW3Wr2gvQopX1k8q2g5V5Iag8Zk6AVENsjwd+3adjwxtp3Dcu2QhOXr8W9NusBU6XcQUohBZ5MA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linux-x64": "1.1.0"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-arm64": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.1.tgz",
+            "integrity": "sha512-DfvyxzHxw4WGdPiTF0SOHnm11Xv4aQexvqhRDAoD00MzHekAj9a/jADXeXYCDFH/DzYruwHbXU7uz+H+nWmSOQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-arm64": "1.1.0"
+            }
+        },
+        "node_modules/@img/sharp-linuxmusl-x64": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.1.tgz",
+            "integrity": "sha512-pax/kTR407vNb9qaSIiWVnQplPcGU8LRIJpDT5o8PdAx5aAA7AS3X9PS8Isw1/WfqgQorPotjrZL3Pqh6C5EBg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-libvips-linuxmusl-x64": "1.1.0"
+            }
+        },
+        "node_modules/@img/sharp-wasm32": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.1.tgz",
+            "integrity": "sha512-YDybQnYrLQfEpzGOQe7OKcyLUCML4YOXl428gOOzBgN6Gw0rv8dpsJ7PqTHxBnXnwXr8S1mYFSLSa727tpz0xg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/runtime": "^1.4.0"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-ia32": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.1.tgz",
+            "integrity": "sha512-WKf/NAZITnonBf3U1LfdjoMgNO5JYRSlhovhRhMxXVdvWYveM4kM3L8m35onYIdh75cOMCo1BexgVQcCDzyoWw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
+        },
+        "node_modules/@img/sharp-win32-x64": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.1.tgz",
+            "integrity": "sha512-hw1iIAHpNE8q3uMIRCgGOeDoz9KtFNarFLQclLxr/LK1VBkj8nby18RjFvr6aP7USRYAjTZW6yisnBWMX571Tw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "Apache-2.0 AND LGPL-3.0-or-later",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            }
         },
         "node_modules/@inquirer/checkbox": {
             "version": "1.5.2",
@@ -11898,15 +12295,15 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.26.tgz",
-            "integrity": "sha512-vO//GJ/YBco+H7xdQhzJxF7ub3SUwft76jwaeOyVVQFHCi5DCnkP16WHB+JBylo4vOKPoZBlR94Z8xBxNBdNJA==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-15.3.1.tgz",
+            "integrity": "sha512-cwK27QdzrMblHSn9DZRV+DQscHXRuJv6MydlJRpFSqJWZrTYMLzKDeyueJNN9MGd8NNiUKzDQADAf+dMLXX7YQ==",
             "license": "MIT"
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.26.tgz",
-            "integrity": "sha512-zDJY8gsKEseGAxG+C2hTMT0w9Nk9N1Sk1qV7vXYz9MEiyRoF5ogQX2+vplyUMIfygnjn9/A04I6yrUTRTuRiyQ==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.3.1.tgz",
+            "integrity": "sha512-hjDw4f4/nla+6wysBL07z52Gs55Gttp5Bsk5/8AncQLJoisvTBP0pRIBK/B16/KqQyH+uN4Ww8KkcAqJODYH3w==",
             "cpu": [
                 "arm64"
             ],
@@ -11920,9 +12317,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.26.tgz",
-            "integrity": "sha512-U0adH5ryLfmTDkahLwG9sUQG2L0a9rYux8crQeC92rPhi3jGQEY47nByQHrVrt3prZigadwj/2HZ1LUUimuSbg==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.3.1.tgz",
+            "integrity": "sha512-q+aw+cJ2ooVYdCEqZVk+T4Ni10jF6Fo5DfpEV51OupMaV5XL6pf3GCzrk6kSSZBsMKZtVC1Zm/xaNBFpA6bJ2g==",
             "cpu": [
                 "x64"
             ],
@@ -11936,9 +12333,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.26.tgz",
-            "integrity": "sha512-SINMl1I7UhfHGM7SoRiw0AbwnLEMUnJ/3XXVmhyptzriHbWvPPbbm0OEVG24uUKhuS1t0nvN/DBvm5kz6ZIqpg==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.3.1.tgz",
+            "integrity": "sha512-wBQ+jGUI3N0QZyWmmvRHjXjTWFy8o+zPFLSOyAyGFI94oJi+kK/LIZFJXeykvgXUk1NLDAEFDZw/NVINhdk9FQ==",
             "cpu": [
                 "arm64"
             ],
@@ -11952,9 +12349,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.26.tgz",
-            "integrity": "sha512-s6JaezoyJK2DxrwHWxLWtJKlqKqTdi/zaYigDXUJ/gmx/72CrzdVZfMvUc6VqnZ7YEvRijvYo+0o4Z9DencduA==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.3.1.tgz",
+            "integrity": "sha512-IIxXEXRti/AulO9lWRHiCpUUR8AR/ZYLPALgiIg/9ENzMzLn3l0NSxVdva7R/VDcuSEBo0eGVCe3evSIHNz0Hg==",
             "cpu": [
                 "arm64"
             ],
@@ -11968,9 +12365,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.26.tgz",
-            "integrity": "sha512-FEXeUQi8/pLr/XI0hKbe0tgbLmHFRhgXOUiPScz2hk0hSmbGiU8aUqVslj/6C6KA38RzXnWoJXo4FMo6aBxjzg==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.3.1.tgz",
+            "integrity": "sha512-bfI4AMhySJbyXQIKH5rmLJ5/BP7bPwuxauTvVEiJ/ADoddaA9fgyNNCcsbu9SlqfHDoZmfI6g2EjzLwbsVTr5A==",
             "cpu": [
                 "x64"
             ],
@@ -11984,9 +12381,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.26.tgz",
-            "integrity": "sha512-BUsomaO4d2DuXhXhgQCVt2jjX4B4/Thts8nDoIruEJkhE5ifeQFtvW5c9JkdOtYvE5p2G0hcwQ0UbRaQmQwaVg==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.3.1.tgz",
+            "integrity": "sha512-FeAbR7FYMWR+Z+M5iSGytVryKHiAsc0x3Nc3J+FD5NVbD5Mqz7fTSy8CYliXinn7T26nDMbpExRUI/4ekTvoiA==",
             "cpu": [
                 "x64"
             ],
@@ -12000,9 +12397,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.26.tgz",
-            "integrity": "sha512-5auwsMVzT7wbB2CZXQxDctpWbdEnEW/e66DyXO1DcgHxIyhP06awu+rHKshZE+lPLIGiwtjo7bsyeuubewwxMw==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.3.1.tgz",
+            "integrity": "sha512-yP7FueWjphQEPpJQ2oKmshk/ppOt+0/bB8JC8svPUZNy0Pi3KbPx2Llkzv1p8CoQa+D2wknINlJpHf3vtChVBw==",
             "cpu": [
                 "arm64"
             ],
@@ -12015,26 +12412,10 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.26.tgz",
-            "integrity": "sha512-GQWg/Vbz9zUGi9X80lOeGsz1rMH/MtFO/XqigDznhhhTfDlDoynCM6982mPCbSlxJ/aveZcKtTlwfAjwhyxDpg==",
-            "cpu": [
-                "ia32"
-            ],
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">= 10"
-            }
-        },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.26.tgz",
-            "integrity": "sha512-2rdB3T1/Gp7bv1eQTTm9d1Y1sv9UuJ2LAwOE0Pe2prHKe32UNscj7YS13fRB37d0GAiGNR+Y7ZcW8YjDI8Ns0w==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.3.1.tgz",
+            "integrity": "sha512-3PMvF2zRJAifcRNni9uMk/gulWfWS+qVI/pagd+4yLF5bcXPZPPH2xlYRYOsUjmCJOXSTAC2PjRzbhsRzR2fDQ==",
             "cpu": [
                 "x64"
             ],
@@ -14544,7 +14925,8 @@
         "node_modules/@swc/counter": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+            "license": "Apache-2.0"
         },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
@@ -14564,34 +14946,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/@testing-library/dom": {
-            "version": "8.20.1",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-            "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
-            "dev": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/runtime": "^7.12.5",
-                "@types/aria-query": "^5.0.1",
-                "aria-query": "5.1.3",
-                "chalk": "^4.1.0",
-                "dom-accessibility-api": "^0.5.9",
-                "lz-string": "^1.5.0",
-                "pretty-format": "^27.0.2"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@testing-library/dom/node_modules/aria-query": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-            "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
-            "dev": true,
-            "dependencies": {
-                "deep-equal": "^2.0.5"
             }
         },
         "node_modules/@testing-library/jest-dom": {
@@ -14639,24 +14993,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/@testing-library/react": {
-            "version": "13.4.0",
-            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-13.4.0.tgz",
-            "integrity": "sha512-sXOGON+WNTh3MLE9rve97ftaZukN3oNf2KjDy7YTx6hcTO2uuLHuCGynMDhFwGw/jYf4OJ2Qk0i4i79qMNNkyw==",
-            "dev": true,
-            "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "@testing-library/dom": "^8.5.0",
-                "@types/react-dom": "^18.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            },
-            "peerDependencies": {
-                "react": "^18.0.0",
-                "react-dom": "^18.0.0"
             }
         },
         "node_modules/@tootallnate/once": {
@@ -14758,7 +15094,8 @@
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -15228,21 +15565,21 @@
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
         },
         "node_modules/@types/react": {
-            "version": "18.3.18",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.18.tgz",
-            "integrity": "sha512-t4yC+vtgnkYjNSKlFx1jkAhH8LgTo2N/7Qvi83kdEaUtMDiwpbLAktKDaAMlRcJ5eSxZkH74eEGt1ky31d7kfQ==",
+            "version": "19.1.3",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
+            "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
+            "license": "MIT",
             "dependencies": {
-                "@types/prop-types": "*",
                 "csstype": "^3.0.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.3.5",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-            "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
-            "dev": true,
+            "version": "19.1.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
+            "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
+            "license": "MIT",
             "peerDependencies": {
-                "@types/react": "^18.0.0"
+                "@types/react": "^19.0.0"
             }
         },
         "node_modules/@types/react-router": {
@@ -18514,7 +18851,8 @@
         "node_modules/client-only": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
-            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+            "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+            "license": "MIT"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -18706,6 +19044,20 @@
             "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.2.tgz",
             "integrity": "sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q=="
         },
+        "node_modules/color": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+            "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "color-convert": "^2.0.1",
+                "color-string": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=12.5.0"
+            }
+        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -18721,6 +19073,17 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "node_modules/color-string": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
         },
         "node_modules/color-support": {
             "version": "1.1.3",
@@ -20053,38 +20416,6 @@
             },
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/deep-equal": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-            "dev": true,
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.5",
-                "es-get-iterator": "^1.1.3",
-                "get-intrinsic": "^1.2.2",
-                "is-arguments": "^1.1.1",
-                "is-array-buffer": "^3.0.2",
-                "is-date-object": "^1.0.5",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.5",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "side-channel": "^1.0.4",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/deep-extend": {
@@ -21610,26 +21941,6 @@
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/es-iterator-helpers": {
@@ -25922,22 +26233,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/is-arguments": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-            "dev": true,
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-array-buffer": {
             "version": "3.0.5",
             "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -29563,6 +29858,7 @@
             "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
             "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "lz-string": "bin/bin.js"
             }
@@ -30653,41 +30949,42 @@
             "peer": true
         },
         "node_modules/next": {
-            "version": "14.2.26",
-            "resolved": "https://registry.npmjs.org/next/-/next-14.2.26.tgz",
-            "integrity": "sha512-b81XSLihMwCfwiUVRRja3LphLo4uBBMZEzBBWMaISbKTwOmq3wPknIETy/8000tr7Gq4WmbuFYPS7jOYIf+ZJw==",
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/next/-/next-15.3.1.tgz",
+            "integrity": "sha512-8+dDV0xNLOgHlyBxP1GwHGVaNXsmp+2NhZEYrXr24GWLHtt27YrBPbPuHvzlhi7kZNYjeJNR93IF5zfFu5UL0g==",
             "license": "MIT",
             "dependencies": {
-                "@next/env": "14.2.26",
-                "@swc/helpers": "0.5.5",
+                "@next/env": "15.3.1",
+                "@swc/counter": "0.1.3",
+                "@swc/helpers": "0.5.15",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001579",
-                "graceful-fs": "^4.2.11",
                 "postcss": "8.4.31",
-                "styled-jsx": "5.1.1"
+                "styled-jsx": "5.1.6"
             },
             "bin": {
                 "next": "dist/bin/next"
             },
             "engines": {
-                "node": ">=18.17.0"
+                "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "14.2.26",
-                "@next/swc-darwin-x64": "14.2.26",
-                "@next/swc-linux-arm64-gnu": "14.2.26",
-                "@next/swc-linux-arm64-musl": "14.2.26",
-                "@next/swc-linux-x64-gnu": "14.2.26",
-                "@next/swc-linux-x64-musl": "14.2.26",
-                "@next/swc-win32-arm64-msvc": "14.2.26",
-                "@next/swc-win32-ia32-msvc": "14.2.26",
-                "@next/swc-win32-x64-msvc": "14.2.26"
+                "@next/swc-darwin-arm64": "15.3.1",
+                "@next/swc-darwin-x64": "15.3.1",
+                "@next/swc-linux-arm64-gnu": "15.3.1",
+                "@next/swc-linux-arm64-musl": "15.3.1",
+                "@next/swc-linux-x64-gnu": "15.3.1",
+                "@next/swc-linux-x64-musl": "15.3.1",
+                "@next/swc-win32-arm64-msvc": "15.3.1",
+                "@next/swc-win32-x64-msvc": "15.3.1",
+                "sharp": "^0.34.1"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
                 "@playwright/test": "^1.41.2",
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0",
+                "babel-plugin-react-compiler": "*",
+                "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+                "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
                 "sass": "^1.3.0"
             },
             "peerDependenciesMeta": {
@@ -30695,6 +30992,9 @@
                     "optional": true
                 },
                 "@playwright/test": {
+                    "optional": true
+                },
+                "babel-plugin-react-compiler": {
                     "optional": true
                 },
                 "sass": {
@@ -30705,15 +31005,6 @@
         "node_modules/next-js-msal-react-sample": {
             "resolved": "samples/msal-react-samples/nextjs-sample",
             "link": true
-        },
-        "node_modules/next/node_modules/@swc/helpers": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-            "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
-            "dependencies": {
-                "@swc/counter": "^0.1.3",
-                "tslib": "^2.4.0"
-            }
         },
         "node_modules/next/node_modules/postcss": {
             "version": "8.4.31",
@@ -31892,22 +32183,6 @@
             "version": "1.13.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
             "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-is": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-            "dev": true,
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1"
-            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -36454,13 +36729,10 @@
             }
         },
         "node_modules/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -36674,16 +36946,15 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-            "peer": true,
+            "version": "19.1.0",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
+            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+            "license": "MIT",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.2"
+                "scheduler": "^0.26.0"
             },
             "peerDependencies": {
-                "react": "^18.3.1"
+                "react": "^19.1.0"
             }
         },
         "node_modules/react-error-overlay": {
@@ -40123,13 +40394,10 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.23.2",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-            "peer": true,
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            }
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+            "license": "MIT"
         },
         "node_modules/schema-utils": {
             "version": "4.3.0",
@@ -40404,6 +40672,60 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/sharp": {
+            "version": "0.34.1",
+            "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.1.tgz",
+            "integrity": "sha512-1j0w61+eVxu7DawFJtnfYcvSv6qPFvfTaqzTQ2BLknVhHTwGS8sc63ZBF4rzkWMBVKybo4S5OBtDdZahh2A1xg==",
+            "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "dependencies": {
+                "color": "^4.2.3",
+                "detect-libc": "^2.0.3",
+                "semver": "^7.7.1"
+            },
+            "engines": {
+                "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/libvips"
+            },
+            "optionalDependencies": {
+                "@img/sharp-darwin-arm64": "0.34.1",
+                "@img/sharp-darwin-x64": "0.34.1",
+                "@img/sharp-libvips-darwin-arm64": "1.1.0",
+                "@img/sharp-libvips-darwin-x64": "1.1.0",
+                "@img/sharp-libvips-linux-arm": "1.1.0",
+                "@img/sharp-libvips-linux-arm64": "1.1.0",
+                "@img/sharp-libvips-linux-ppc64": "1.1.0",
+                "@img/sharp-libvips-linux-s390x": "1.1.0",
+                "@img/sharp-libvips-linux-x64": "1.1.0",
+                "@img/sharp-libvips-linuxmusl-arm64": "1.1.0",
+                "@img/sharp-libvips-linuxmusl-x64": "1.1.0",
+                "@img/sharp-linux-arm": "0.34.1",
+                "@img/sharp-linux-arm64": "0.34.1",
+                "@img/sharp-linux-s390x": "0.34.1",
+                "@img/sharp-linux-x64": "0.34.1",
+                "@img/sharp-linuxmusl-arm64": "0.34.1",
+                "@img/sharp-linuxmusl-x64": "0.34.1",
+                "@img/sharp-wasm32": "0.34.1",
+                "@img/sharp-win32-ia32": "0.34.1",
+                "@img/sharp-win32-x64": "0.34.1"
+            }
+        },
+        "node_modules/sharp/node_modules/semver": {
+            "version": "7.7.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+            "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+            "license": "ISC",
+            "optional": true,
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/shebang-command": {
@@ -40857,6 +41179,23 @@
                 "once": "^1.3.1",
                 "simple-concat": "^1.0.0"
             }
+        },
+        "node_modules/simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "is-arrayish": "^0.3.1"
+            }
+        },
+        "node_modules/simple-swizzle/node_modules/is-arrayish": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
+            "license": "MIT",
+            "optional": true
         },
         "node_modules/simple-update-notifier": {
             "version": "1.1.0",
@@ -41461,19 +41800,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/stop-iteration-iterator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-            "dev": true,
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "internal-slot": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/stoppable": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
@@ -41883,9 +42209,10 @@
             }
         },
         "node_modules/styled-jsx": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
-            "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+            "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+            "license": "MIT",
             "dependencies": {
                 "client-only": "0.0.1"
             },
@@ -41893,7 +42220,7 @@
                 "node": ">= 12.0.0"
             },
             "peerDependencies": {
-                "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+                "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
             },
             "peerDependenciesMeta": {
                 "@babel/core": {
@@ -60690,26 +61017,6 @@
                 "typescript": "~4.5.4"
             }
         },
-        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/@types/react": {
-            "version": "19.1.3",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
-            "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "csstype": "^3.0.2"
-            }
-        },
-        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/@types/react-dom": {
-            "version": "19.1.3",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
-            "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "^19.0.0"
-            }
-        },
         "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/@vercel/webpack-asset-relocator-loader": {
             "version": "1.7.3",
             "resolved": "https://registry.npmjs.org/@vercel/webpack-asset-relocator-loader/-/webpack-asset-relocator-loader-1.7.3.tgz",
@@ -60791,33 +61098,6 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
-        },
-        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/react": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/react-dom": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-            "license": "MIT",
-            "dependencies": {
-                "scheduler": "^0.26.0"
-            },
-            "peerDependencies": {
-                "react": "^19.1.0"
-            }
-        },
-        "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/scheduler": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-            "license": "MIT"
         },
         "samples/msal-node-samples/ElectronSystemBrowserTestApp/node_modules/ts-node": {
             "version": "10.9.2",
@@ -61185,33 +61465,6 @@
                 "ts-jest": "^29.1.0"
             }
         },
-        "samples/msal-react-samples/b2c-sample/node_modules/react": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "samples/msal-react-samples/b2c-sample/node_modules/react-dom": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-            "license": "MIT",
-            "dependencies": {
-                "scheduler": "^0.26.0"
-            },
-            "peerDependencies": {
-                "react": "^19.1.0"
-            }
-        },
-        "samples/msal-react-samples/b2c-sample/node_modules/scheduler": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-            "license": "MIT"
-        },
         "samples/msal-react-samples/nextjs-sample": {
             "name": "next-js-msal-react-sample",
             "version": "0.1.0",
@@ -61224,7 +61477,7 @@
                 "@emotion/styled": "^11.10.5",
                 "@mui/icons-material": "^5.10.14",
                 "@mui/material": "^5.10.14",
-                "next": "^14.2.26",
+                "next": "^15.3.1",
                 "react": "^19.1.0",
                 "react-dom": "^19.1.0"
             },
@@ -61235,33 +61488,6 @@
                 "jest-junit": "^16.0.0",
                 "ts-jest": "^29.1.0"
             }
-        },
-        "samples/msal-react-samples/nextjs-sample/node_modules/react": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "samples/msal-react-samples/nextjs-sample/node_modules/react-dom": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-            "license": "MIT",
-            "dependencies": {
-                "scheduler": "^0.26.0"
-            },
-            "peerDependencies": {
-                "react": "^19.1.0"
-            }
-        },
-        "samples/msal-react-samples/nextjs-sample/node_modules/scheduler": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-            "license": "MIT"
         },
         "samples/msal-react-samples/react-router-sample": {
             "version": "0.1.0",
@@ -61286,33 +61512,6 @@
                 "jest-junit": "^16.0.0",
                 "ts-jest": "^29.1.0"
             }
-        },
-        "samples/msal-react-samples/react-router-sample/node_modules/react": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "samples/msal-react-samples/react-router-sample/node_modules/react-dom": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-            "license": "MIT",
-            "dependencies": {
-                "scheduler": "^0.26.0"
-            },
-            "peerDependencies": {
-                "react": "^19.1.0"
-            }
-        },
-        "samples/msal-react-samples/react-router-sample/node_modules/scheduler": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-            "license": "MIT"
         },
         "samples/msal-react-samples/typescript-sample": {
             "version": "0.1.0",
@@ -61346,51 +61545,6 @@
             "version": "16.18.125",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.125.tgz",
             "integrity": "sha512-w7U5ojboSPfZP4zD98d+/cjcN2BDW6lKH2M0ubipt8L8vUC7qUAC6ENKGSJL4tEktH2Saw2K4y1uwSjyRGKMhw=="
-        },
-        "samples/msal-react-samples/typescript-sample/node_modules/@types/react": {
-            "version": "19.1.3",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.3.tgz",
-            "integrity": "sha512-dLWQ+Z0CkIvK1J8+wrDPwGxEYFA4RAyHoZPxHVGspYmFVnwGSNT24cGIhFJrtfRnWVuW8X7NO52gCXmhkVUWGQ==",
-            "license": "MIT",
-            "dependencies": {
-                "csstype": "^3.0.2"
-            }
-        },
-        "samples/msal-react-samples/typescript-sample/node_modules/@types/react-dom": {
-            "version": "19.1.3",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.3.tgz",
-            "integrity": "sha512-rJXC08OG0h3W6wDMFxQrZF00Kq6qQvw0djHRdzl3U5DnIERz0MRce3WVc7IS6JYBwtaP/DwYtRRjVlvivNveKg==",
-            "license": "MIT",
-            "peerDependencies": {
-                "@types/react": "^19.0.0"
-            }
-        },
-        "samples/msal-react-samples/typescript-sample/node_modules/react": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "samples/msal-react-samples/typescript-sample/node_modules/react-dom": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-            "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
-            "license": "MIT",
-            "dependencies": {
-                "scheduler": "^0.26.0"
-            },
-            "peerDependencies": {
-                "react": "^19.1.0"
-            }
-        },
-        "samples/msal-react-samples/typescript-sample/node_modules/scheduler": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-            "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-            "license": "MIT"
         },
         "shared-configs/eslint-config-msal": {
             "version": "0.0.0",

--- a/samples/msal-node-samples/ElectronSystemBrowserTestApp/package.json
+++ b/samples/msal-node-samples/ElectronSystemBrowserTestApp/package.json
@@ -31,8 +31,8 @@
         "@electron/asar": "^3.2.3",
         "@playwright/test": "^1.31.1",
         "@types/jest": "^29.5.0",
-        "@types/react": "^18.0.28",
-        "@types/react-dom": "^18.0.11",
+        "@types/react": "^19.1.3",
+        "@types/react-dom": "^19.1.3",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "@vercel/webpack-asset-relocator-loader": "1.7.3",
@@ -60,9 +60,9 @@
         "axios": "^1.8.2",
         "bootstrap": "^5.0.0",
         "electron-squirrel-startup": "^1.0.0",
-        "react": "^18.2.0",
+        "react": "^19.1.0",
         "react-bootstrap": "^2.7.2",
-        "react-dom": "^18.2.0",
+        "react-dom": "^19.1.0",
         "react-router-dom": "^6.9.0"
     },
     "config": {

--- a/samples/msal-react-samples/nextjs-sample/next-env.d.ts
+++ b/samples/msal-react-samples/nextjs-sample/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/samples/msal-react-samples/nextjs-sample/package.json
+++ b/samples/msal-react-samples/nextjs-sample/package.json
@@ -18,7 +18,7 @@
     "@emotion/styled": "^11.10.5",
     "@mui/icons-material": "^5.10.14",
     "@mui/material": "^5.10.14",
-    "next": "^14.2.26",
+    "next": "^15.3.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },


### PR DESCRIPTION
Had to update `@testing-library/react` and `next` to versions supporting react 19, along with the electron react sample.

There's now only one entry of the react packages in the root node_modules.