### PR TITLE
fix: JSX moved to React namespace

### DIFF
--- a/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/app/components/PageLayout.tsx
+++ b/samples/msal-node-samples/ElectronSystemBrowserTestApp/src/app/components/PageLayout.tsx
@@ -4,7 +4,7 @@ import { NavigationBar } from "./NavigationBar";
 
 type PageLayoutProps = {
     account: AccountInfo;
-    children: JSX.Element;
+    children: React.JSX.Element;
 };
 
 export const PageLayout = (props: PageLayoutProps) => {


### PR DESCRIPTION
Sorry, one last fix, seems the electron sample broke as it used JSX.Element, which was moved to React.JSX.Element in react 19.